### PR TITLE
rework app layout

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -2,8 +2,8 @@ import { AppProps } from "$fresh/server.ts";
 import BrandGithub from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/brand-github.tsx";
 export default function App({ Component }: AppProps) {
   return (
-    <body class="bg-gray-100 min-h-screen grid">
-      <div class="px-4 pt-8 mx-auto w-full max-w-screen-md">
+    <body class="bg-gray-100 min-h-screen flex flex-col">
+      <div class="px-4 pt-8 mx-auto w-full max-w-screen-md flex-1">
         <Component />
       </div>
       <div class="bg-gray-800 mt-24 py-8 text-white text-center flex justify-center items-center gap-2">

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -2,8 +2,8 @@ import { AppProps } from "$fresh/server.ts";
 import BrandGithub from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/brand-github.tsx";
 export default function App({ Component }: AppProps) {
   return (
-    <body class="bg-gray-100">
-      <div class="px-4 pt-8 mx-auto max-w-screen-md">
+    <body class="bg-gray-100 min-h-screen grid">
+      <div class="px-4 pt-8 mx-auto w-full max-w-screen-md">
         <Component />
       </div>
       <div class="bg-gray-800 mt-24 py-8 text-white text-center flex justify-center items-center gap-2">


### PR DESCRIPTION
This commit realigns the app layout so the footer stays at the bottom of a page without leaving an unwanted empty whitespace.

| before | after |
| ------- | ----- | 
| ![image](https://user-images.githubusercontent.com/63919069/235452111-61ccdfc0-ff10-49e5-b710-83f506e55429.png) | ![image](https://user-images.githubusercontent.com/63919069/235452128-6e3a3053-66e4-4063-accb-221c9df81ea8.png) |

### filled page
![image](https://user-images.githubusercontent.com/63919069/235452216-aa27333b-1d53-4204-8002-de46c6542e63.png)

### mobile (galaxy s20 ultra)
| empty | filled |
| ------- | ----- | 
| ![image](https://user-images.githubusercontent.com/63919069/235452538-46bc7c5a-2528-4cf7-a0d7-d1875ccd74dd.png) | ![image](https://user-images.githubusercontent.com/63919069/235452625-f9b8ea16-ecbe-423e-8ed3-1719a64b9df1.png) |
