### PR TITLE
Feature: adding `undo` functionality with `ctrl + z` keys

### DIFF
--- a/islands/canvas.tsx
+++ b/islands/canvas.tsx
@@ -119,28 +119,30 @@ export default function Canvas(props: { uid: string }) {
     const canvas = canvasRef.current as HTMLCanvasElement;
     const ctx = getContext(canvas);
     const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    const previous = imageDataList[imageDataList.length - 1];
-    if (previous !== imageData.data) setImageDataList([...imageDataList, imageData.data]);
+    setImageDataList([...imageDataList, imageData.data]);
   };
+
+  const undo = (e: KeyboardEvent) => {
+    if (e.ctrlKey && e.key === "z") {
+      const canvas = canvasRef.current as HTMLCanvasElement;
+      const ctx = getContext(canvas);
+
+      const imageDataListCopy = imageDataList.slice(0, -1);
+
+      const lastImageData = imageDataListCopy[imageDataListCopy.length - 1];
+      if (lastImageData) {
+        const imageData = new ImageData(lastImageData, canvas.width, canvas.height);
+        ctx.putImageData(imageData, 0, 0);
+
+        setImageDataList(imageDataListCopy);
+      } else {
+        clear();
+      }
+    }
+  };
+
   
   useEffect(() => {
-    const undo = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === "z") {
-        const canvas = canvasRef.current as HTMLCanvasElement;
-        const ctx = getContext(canvas);
-        const previous = imageDataList[imageDataList.length - 1];
-        if (previous) {
-          ctx.putImageData(
-            new ImageData(previous, canvas.width, canvas.height),
-            0,
-            0,
-          );
-          setImageDataList(imageDataList.slice(0, imageDataList.length - 1));
-        } else {
-          clear();
-        }
-      }
-    };
     self.addEventListener("keydown", undo);
     return () => {
       self.removeEventListener("keydown", undo);

--- a/islands/canvas.tsx
+++ b/islands/canvas.tsx
@@ -98,6 +98,7 @@ export default function Canvas(props: { uid: string }) {
   };
 
   function clear() {
+    if (!imageDataList.length) return;
     const canvas = canvasRef.current as HTMLCanvasElement;
     const ctx = getContext(canvas);
     ctx.fillStyle = pallete[pallete.length - 1];


### PR DESCRIPTION
## Purpose
Using the `clear` function works, but eliminates all the drawing, which isn't the best thing to do if the user just wants to eliminate an recent error/change. Undoing with `ctrl+z` solves this problem.

**Changes**:
- An state will be storing every image data states of the canvas after every drawing action, so it's easy to just restore to the previous one when undoing.
- Using an event listener to watch the combination key press (`ctrl + z`) and binding the `undo` function to it.
- `clear` function now only executes if `imageDataList` isn't empty.
